### PR TITLE
Add devcontainer and .gitattributes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,50 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+    "name": "Docker outside of Docker",
+    // SELinux fix
+    "workspaceMount": "",
+    "runArgs": ["--volume=${localWorkspaceFolder}:/workspaces/${localWorkspaceFolderBasename}:Z"],
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/base:bullseye",
+    
+    // Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+			"version": "latest",
+			"enableNonRootDocker": "true",
+			"moby": "true"
+		}
+	},
+    
+    // Configure tool-specific properties.
+    "customizations": {
+        "vscode": {
+            "extensions": [
+				"streetsidesoftware.code-spell-checker"
+			],
+            "settings": {
+                "cSpell.words": [
+                    "Containerfile",
+                    "datadir",
+                    "devcontainers",
+                    "dockercompose",
+                    "gradio",
+                    "moby",
+                    "universonic",
+                    "webui"
+                ],
+                "files.associations": {
+                    "*.yml": "dockercompose",
+                    "*.yaml": "dockercompose"
+                }
+            }
+        }
+    }
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
Another developer quality of life improvement. Adding the ability to code in a GitHub codespace or locally in a container using docker. This is using a "docker outside of docker" dev container for a consistent dev environment that provides Docker linting, intellisense, and other various tools provided by the Docker extension.

.gitattributes added to force correct end of line characters even on Windows. People using Windows can spin up a codespace right on GitHub and connect it to their locally installed VScode without needing docker or podman installed locally.